### PR TITLE
Remove trailing slash from URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Sjoerd Langkemper
 # email: your-email@domain.com
 description: "Web application security"
 baseurl: ""
-url: "http://www.sjoerdlangkemper.nl/"
+url: "http://www.sjoerdlangkemper.nl"
 github_username:  Sjord
 future: false
 


### PR DESCRIPTION
This causes double slashes in the HTML source