### PR TITLE
Put only excerpt in RSS, not full post

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -14,7 +14,7 @@ layout: none
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>{{ post.excerpt | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>


### PR DESCRIPTION
Mainly to reduce the size of the RSS feed.