### PR TITLE
Remove Amazon associates link

### DIFF
--- a/_posts/2016-12-18-book-review-bulletproof-ssl-tls.md
+++ b/_posts/2016-12-18-book-review-bulletproof-ssl-tls.md
@@ -5,17 +5,17 @@ thumbnail: bulletproofssl-240.jpg
 date: 2017-01-05
 ---
 
-Recently I read the book [Bulletproof SSL and TLS](https://www.amazon.com/gp/product/1907117040/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1907117040&linkCode=as2&tag=sjoerdlangkem-20&linkId=979c050291676d0d04a8e0e3a4c84399). I think it is a great book and I would recommend reading it. In this post I describe what you can expect from this book.
+Recently I read the book [Bulletproof SSL and TLS](https://www.feistyduck.com/books/bulletproof-ssl-and-tls/). I think it is a great book and I would recommend reading it. In this post I describe what you can expect from this book.
 
 [![Bulletproof SSL and TLS](/images/bulletproofssl-book.png)](https://www.amazon.com/gp/product/1907117040/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1907117040&linkCode=as2&tag=sjoerdlangkem-20&linkId=979c050291676d0d04a8e0e3a4c84399)
 
 ## About the author
 
-[Bulletproof SSL and TLS](https://www.amazon.com/gp/product/1907117040/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1907117040&linkCode=as2&tag=sjoerdlangkem-20&linkId=979c050291676d0d04a8e0e3a4c84399) is written by Ivan Ristić. You may know him from [SSL Labs](https://www.ssllabs.com/), where you can test the TLS configuration of your site. Ivan started working at [Qualys](https://www.qualys.com/) after it acquired SSL Labs from him. This year he founded [Hardenize](https://www.hardenize.com/), a tool to monitor the security of your web site.
+[Bulletproof SSL and TLS](https://www.feistyduck.com/books/bulletproof-ssl-and-tls/) is written by Ivan Ristić. You may know him from [SSL Labs](https://www.ssllabs.com/), where you can test the TLS configuration of your site. Ivan started working at [Qualys](https://www.qualys.com/) after it acquired SSL Labs from him. This year he founded [Hardenize](https://www.hardenize.com/), a tool to monitor the security of your web site.
 
 ## About the book
 
-[Bulletproof SSL and TLS](https://www.amazon.com/gp/product/1907117040/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1907117040&linkCode=as2&tag=sjoerdlangkem-20&linkId=979c050291676d0d04a8e0e3a4c84399) describes TLS, and specifically its usage in HTTPS. Under some conditions, TLS can provide perfect transport level security. The book describes how you should use it to obtain that, and what the limitations are. 
+[Bulletproof SSL and TLS](https://www.feistyduck.com/books/bulletproof-ssl-and-tls/) describes TLS, and specifically its usage in HTTPS. Under some conditions, TLS can provide perfect transport level security. The book describes how you should use it to obtain that, and what the limitations are. 
 
 Although it describes the theory of TLS, it does not leave behind the real world. In chapter 4, for example, several attacks on SSL certificates are described that happened in recent years. A startling number of breaches are laid out where attackers could issue their own certificates. Some of these were hacks, as in the case of DigiNotar. Others are the result of negligence. For example, TurkTrust accidentally marked two certificates as CA certificates, which were later used to sign fraudulent certificates.
 


### PR DESCRIPTION
Because we failed to get any referrals.