### PR TITLE
Don't show icons when printing

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -51,6 +51,12 @@ a:visited { color: #205caa; }
   }
 }
 
+@media print {
+  .sidebar .icons {
+    display: none;
+  }
+}
+
 .sidebar .icons img {
   width: 36px;
   margin: 6px;


### PR DESCRIPTION
Because you can't click on them on paper.